### PR TITLE
Add 'test_time' parameter to increase test time.

### DIFF
--- a/2019/harness/main.js
+++ b/2019/harness/main.js
@@ -53,16 +53,10 @@ var parseParams = function(testSuiteConfig) {
 
   // See: https://wiki.mozilla.org/Performance_sheriffing/Raptor
   config.is_raptor = util.stringToBoolean(parseParam('raptor', false));
-  config.longtest = util.stringToBoolean(parseParam('longtest', false));
 
-  // test_time parameter is ignored when longtest is false
-  config.testTime = 15;
-
-  if (config.longtest) {
-    // Set a higher default timeout for long tests
-    config.timeout = Number(parseParam('timeout', 1200000));
-    config.testTime = Number(parseParam('test_time', 300));
-  }
+  // If test_time parameter is greater than 15, we use a different
+  // streaming method in the msutil.js setupMse function
+  config.testTime = Number(parseParam('test_time', 15));
 
   config.is_cobalt = util.isCobalt();
   config.support_hdr = util.supportHdr();

--- a/2019/harness/main.js
+++ b/2019/harness/main.js
@@ -53,6 +53,16 @@ var parseParams = function(testSuiteConfig) {
 
   // See: https://wiki.mozilla.org/Performance_sheriffing/Raptor
   config.is_raptor = util.stringToBoolean(parseParam('raptor', false));
+  config.longtest = util.stringToBoolean(parseParam('longtest', false));
+
+  // test_time parameter is ignored when longtest is false
+  config.testTime = 15;
+
+  if (config.longtest) {
+    // Set a higher default timeout for long tests
+    config.timeout = Number(parseParam('timeout', 1200000));
+    config.testTime = Number(parseParam('test_time', 300));
+  }
 
   config.is_cobalt = util.isCobalt();
   config.support_hdr = util.supportHdr();

--- a/2019/lib/mse/msutil.js
+++ b/2019/lib/mse/msutil.js
@@ -781,7 +781,21 @@ window.setupMse = function(video, runner, videoStreams, audioStreams) {
       var audioStream = audioStreams[audioStreamIdx];
       if (audioStream != null) {
         audioSbs.push(ms.addSourceBuffer(audioStream.mimetype));
-        appendLoop(audioStream, audioSbs[audioSbs.length - 1]);
+        if (harnessConfig.longtest) {
+          var audioChain = new ResetInit(new FixedAppendSize(
+              new FileSource(audioStream.src, runner.XHRManager, runner.timeouts),
+              65536));
+          appendUntil(
+            runner.timeouts,
+            video,
+            audioSbs[audioSbs.length - 1],
+            audioChain,
+            harnessConfig.testTime + 10,
+            function() {}
+          );
+        } else {
+          appendLoop(audioStream, audioSbs[audioSbs.length - 1]);
+        }
       }
     }
 
@@ -789,7 +803,22 @@ window.setupMse = function(video, runner, videoStreams, audioStreams) {
       var videoStream = videoStreams[videoStreamIdx];
       if (videoStream != null) {
         videoSbs.push(ms.addSourceBuffer(videoStream.mimetype));
-        appendLoop(videoStream, videoSbs[videoSbs.length - 1]);
+        if (harnessConfig.longtest) {
+          var videoChain = new ResetInit(new FixedAppendSize(
+              new FileSource(videoStream.src, runner.XHRManager, runner.timeouts),
+              65536));
+          console.log(harnessConfig.testTime)
+          appendUntil(
+            runner.timeouts,
+            video,
+            videoSbs[audioSbs.length - 1],
+            videoChain,
+            harnessConfig.testTime,
+            function() {}
+          );
+        } else {
+          appendLoop(videoStream, videoSbs[videoSbs.length - 1]);
+        }
       }
     }
   }

--- a/2019/lib/mse/msutil.js
+++ b/2019/lib/mse/msutil.js
@@ -781,7 +781,7 @@ window.setupMse = function(video, runner, videoStreams, audioStreams) {
       var audioStream = audioStreams[audioStreamIdx];
       if (audioStream != null) {
         audioSbs.push(ms.addSourceBuffer(audioStream.mimetype));
-        if (harnessConfig.longtest) {
+        if (harnessConfig.testTime > 15) {
           var audioChain = new ResetInit(new FixedAppendSize(
               new FileSource(audioStream.src, runner.XHRManager, runner.timeouts),
               65536));
@@ -803,7 +803,7 @@ window.setupMse = function(video, runner, videoStreams, audioStreams) {
       var videoStream = videoStreams[videoStreamIdx];
       if (videoStream != null) {
         videoSbs.push(ms.addSourceBuffer(videoStream.mimetype));
-        if (harnessConfig.longtest) {
+        if (harnessConfig.testTime > 15) {
           var videoChain = new ResetInit(new FixedAppendSize(
               new FileSource(videoStream.src, runner.XHRManager, runner.timeouts),
               65536));
@@ -813,7 +813,7 @@ window.setupMse = function(video, runner, videoStreams, audioStreams) {
             video,
             videoSbs[videoSbs.length - 1],
             videoChain,
-            harnessConfig.testTime,
+            harnessConfig.testTime + 10,
             function() {}
           );
         } else {

--- a/2019/lib/mse/msutil.js
+++ b/2019/lib/mse/msutil.js
@@ -811,7 +811,7 @@ window.setupMse = function(video, runner, videoStreams, audioStreams) {
           appendUntil(
             runner.timeouts,
             video,
-            videoSbs[audioSbs.length - 1],
+            videoSbs[videoSbs.length - 1],
             videoChain,
             harnessConfig.testTime,
             function() {}

--- a/2019/media/playbackperfTest.js
+++ b/2019/media/playbackperfTest.js
@@ -25,14 +25,15 @@ var PlaybackperfTest = function() {
 
 var webkitPrefix = MediaSource.prototype.version.indexOf('webkit') >= 0;
 var tests = [];
-var testTime = 15;
-TestBase.timeout = 70000; // 70 sec to compensate for 0.25 playbackRate tests.
+var testTime = harnessConfig.testTime;
 
-// For long tests, get the timeout and testing time from the harness config
-// parameters.
-if (harnessConfig.longtest) {
+if (harnessConfig.timeout == TestBase.timeout) {
+  // Use a timeout (in ms) that is 4x highger than testTime
+  // to compensate for 0.25 playbackRate tests.
+  TestBase.timeout = harnessConfig.testTime * 4000;
+} else {
+  // A non-default timeout was supplied, use that instead
   TestBase.timeout = harnessConfig.timeout;
-  testTime = harnessConfig.testTime
 }
 
 var info = 'No MSE Support!';

--- a/2019/media/playbackperfTest.js
+++ b/2019/media/playbackperfTest.js
@@ -28,8 +28,8 @@ var tests = [];
 var testTime = 15;
 TestBase.timeout = 70000; // 70 sec to compensate for 0.25 playbackRate tests.
 
-// For long tests, increase the default timeout to 1200 sec and
-// parse parameters in case a different timeout was requested.
+// For long tests, get the timeout and testing time from the harness config
+// parameters.
 if (harnessConfig.longtest) {
   TestBase.timeout = harnessConfig.timeout;
   testTime = harnessConfig.testTime

--- a/2019/media/playbackperfTest.js
+++ b/2019/media/playbackperfTest.js
@@ -25,7 +25,16 @@ var PlaybackperfTest = function() {
 
 var webkitPrefix = MediaSource.prototype.version.indexOf('webkit') >= 0;
 var tests = [];
+var testTime = 15;
 TestBase.timeout = 70000; // 70 sec to compensate for 0.25 playbackRate tests.
+
+// For long tests, increase the default timeout to 1200 sec and
+// parse parameters in case a different timeout was requested.
+if (harnessConfig.longtest) {
+  TestBase.timeout = harnessConfig.timeout;
+  testTime = harnessConfig.testTime
+}
+
 var info = 'No MSE Support!';
 if (window.MediaSource) {
   info = 'webkit prefix: ' + webkitPrefix.toString();
@@ -131,7 +140,7 @@ var createFrameDropValidationTest = function(videoStream1, videoStream2) {
         test.prototype.status = '(' + totalDroppedFrames + '/' +
             totalDecodedFrames + ')';
         runner.updateStatus();
-        if (!video.paused && video.currentTime >= 15) {
+        if (!video.paused && video.currentTime >= testTime) {
           video.removeEventListener('timeupdate', onTimeUpdate);
           video.pause();
           test.prototype.decoded_frames = totalDecodedFrames;
@@ -195,7 +204,7 @@ var createPlaybackPerfTest = function(
       test.prototype.status = '(' + totalDroppedFrames + '/' +
           totalDecodedFrames + ')';
       runner.updateStatus();
-      if (!video.paused && video.currentTime >= 15) {
+      if (!video.paused && video.currentTime >= testTime) {
         video.removeEventListener('timeupdate', onTimeUpdate);
         video.pause();
         test.prototype.decoded_frames = totalDecodedFrames;


### PR DESCRIPTION
This patch adds the ability to do longer tests in the "Playback Performance Tests" suite. It adds a parameter `test_time` to modify the time of the test.